### PR TITLE
Remove Atlas references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 vagrant_cloud
 =============
-Minimalistic ruby client for the [HashiCorp Atlas API](https://vagrantcloud.com/docs) (previously *Vagrant Cloud API*).
+Ruby client for the [Vagrant Cloud API](https://www.vagrantup.com/docs/vagrant-cloud/api.html).
 
 [![Build Status](https://img.shields.io/travis/hashicorp/vagrant_cloud/master.svg)](https://travis-ci.org/hashicorp/vagrant_cloud)
 [![Gem Version](https://img.shields.io/gem/v/vagrant_cloud.svg)](https://rubygems.org/gems/vagrant_cloud)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ puts provider.download_url
 ```
 
 Example CLI usage:
-Create a version and provider within an existing Box, upload a file to be hosted by Vagrant/Atlas, and release the version
+Create a version and provider within an existing Box, upload a file to be hosted by Vagrant Cloud, and release the version
 ```sh
 vagrant_cloud create_version --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION
 vagrant_cloud create_provider --username $USERNAME --token $VAGRANT_CLOUD_TOKEN --box $BOX_NAME --version $BOX_VERSION

--- a/lib/vagrant_cloud/cli.rb
+++ b/lib/vagrant_cloud/cli.rb
@@ -36,10 +36,10 @@ module VagrantCloud
       provider
     end
 
-    desc 'upload_file', 'upload a file for Atlas to host to an existing version and provider'
+    desc 'upload_file', 'upload a file for Vagrant Cloud to host to an existing version and provider'
     method_option :version, alias: '-v', required: true, desc: 'version within the box'
     method_option :provider, alias: '-p', default: 'virtualbox', desc: 'the provider for the box; default: virtualbox'
-    method_option :provider_file_path, alias: '-pfp', required: true, desc: 'path to file to be uploaded for Atlast hosting'
+    method_option :provider_file_path, alias: '-pfp', required: true, desc: 'path to file to be uploaded for Vagrant Cloud hosting'
     def upload_file
       get_provider(options[:provider]).upload_file(options[:provider_file_path])
     end


### PR DESCRIPTION
Vagrant Cloud was extracted in June 2017 to its own service.