### PR TITLE
Remove the JSON runtime dependency

### DIFF
--- a/lib/vagrant_cloud/client.rb
+++ b/lib/vagrant_cloud/client.rb
@@ -50,11 +50,24 @@ module VagrantCloud
       begin
         result = RestClient::Request.execute(request_params)
 
-        parsed_result = JSON.parse(result)
-        parsed_result
+        parse_json(result)
       rescue RestClient::ExceptionWithResponse => e
         raise ClientError.new(e.message, e.http_body, e.http_code)
       end
+    end
+
+    protected
+
+    # Parse string of JSON
+    #
+    # @param [String] string JSON encoded string
+    # @return [Object]
+    # @note This is included to provide expected behavior on
+    # Ruby 2.3. Once it has reached EOL this can be removed.
+    def parse_json(string)
+      JSON.parse(string)
+    rescue JSON::ParserError
+      raise if string != 'null'
     end
   end
 end

--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/hashicorp/vagrant_cloud'
   s.license     = 'MIT'
 
-  s.add_runtime_dependency 'json', '~> 2.1.0'
   s.add_runtime_dependency 'rest-client', '~> 2.0.2'
 
   s.add_development_dependency 'rake', '~> 10.4'


### PR DESCRIPTION
Rely on JSON provided by stdlib by default. This can be modified
at runtime by installing the RubyGem. Prevents dependency conflicts
with other libraries that may impose constraints on the JSON library.