### PR TITLE
Fix ensure_box when the box doesn't exist

### DIFF
--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -104,10 +104,10 @@ module VagrantCloud
     def ensure_box(name, *args)
       params = box_params(*args)
 
-      begin
+      begin # try to read the box data
         box = get_box(name)
         box.data
-      rescue RestClient::ResourceNotFound
+      rescue VagrantCloud::ClientError # it's probably not a box so create
         box = create_box(name, params)
         # If we've just created the box, we're done.
         return box

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -104,10 +104,15 @@ module VagrantCloud
     def ensure_box(name, *args)
       params = box_params(*args)
 
-      begin # try to read the box data
+      # try to read the box data
+      begin
         box = get_box(name)
         box.data
-      rescue VagrantCloud::ClientError # it's probably not a box so create
+      rescue VagrantCloud::ClientError => err
+        # Check if it's a 404 error. If so, then create
+        # the missing box
+        raise if err.error_code != 404
+
         box = create_box(name, params)
         # If we've just created the box, we're done.
         return box

--- a/lib/vagrant_cloud/errors.rb
+++ b/lib/vagrant_cloud/errors.rb
@@ -4,21 +4,24 @@ module VagrantCloud
     attr_accessor :error_code
 
     def initialize(msg, http_body, http_code)
+      message = msg
+
       begin
         errors = JSON.parse(http_body)
-        vagrant_cloud_msg = errors['errors']
-
-        if vagrant_cloud_msg.is_a?(Array)
-          message = msg + ' - ' + vagrant_cloud_msg.join(', ').to_s
-        else
-          message = msg + ' - ' + vagrant_cloud_msg
+        if errors.is_a?(Hash)
+          vagrant_cloud_msg = errors['errors']
+          if vagrant_cloud_msg.is_a?(Array)
+            message = msg + ' - ' + vagrant_cloud_msg.map(&:to_s).join(', ').to_s
+          elsif !vagrant_cloud_msg.to_s.empty?
+            message = msg + ' - ' + vagrant_cloud_msg.to_s
+          end
         end
-      rescue JSON::ParserError
-        message = msg
+      rescue JSON::ParserError => err
+        vagrant_cloud_msg = err.message
       end
 
       @error_arr = vagrant_cloud_msg
-      @error_code = http_code
+      @error_code = http_code.to_i
       super(message)
     end
   end

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -131,7 +131,7 @@ module VagrantCloud
     describe '.ensure_box' do
       it 'creates nonexisting boxes' do
         box_requested = Box.new(account, 'foo')
-        expect(box_requested).to receive(:data).and_raise(RestClient::ResourceNotFound)
+        expect(box_requested).to receive(:data).and_raise(VagrantCloud::ClientError)
 
         box_created = Box.new(account, 'foo', 'description_markdown' => 'desc',
                                               'short_description' => 'desc',

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -4,6 +4,16 @@ require 'vagrant_cloud'
 module VagrantCloud
   describe Account do
     let(:account) { Account.new('my-acc', 'my-token') }
+    let(:client_error) {
+      VagrantCloud::ClientError.new(
+        client_error_message,
+        client_error_http_body,
+        client_error_http_code
+      )
+    }
+    let(:client_error_message) { '' }
+    let(:client_error_http_body) { '' }
+    let(:client_error_http_code) { 400 }
 
     describe '#initialize' do
       it 'stores credentials' do
@@ -129,9 +139,11 @@ module VagrantCloud
     end
 
     describe '.ensure_box' do
+      let(:client_error_http_code) { 404 }
+
       it 'creates nonexisting boxes' do
         box_requested = Box.new(account, 'foo')
-        expect(box_requested).to receive(:data).and_raise(VagrantCloud::ClientError)
+        expect(box_requested).to receive(:data).and_raise(client_error)
 
         box_created = Box.new(account, 'foo', 'description_markdown' => 'desc',
                                               'short_description' => 'desc',

--- a/spec/vagrant_cloud/errors_spec.rb
+++ b/spec/vagrant_cloud/errors_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+require 'vagrant_cloud'
+
+module VagrantCloud
+  describe ClientError do
+    let(:subject) { described_class.new(message, body, code) }
+    let(:message) { 'default error' }
+    let(:body) { '' }
+    let(:code) { 0 }
+
+    describe '#initialize' do
+      it 'is a StandardError' do
+        expect(subject).to be_a_kind_of(StandardError)
+      end
+
+      context 'with message' do
+        let(:message) { 'custom message' }
+
+        it 'should set the message' do
+          expect(subject.message).to eq(message)
+        end
+
+        it 'should output custom message with #to_s' do
+          expect(subject.to_s).to eq(message)
+        end
+      end
+
+      context 'with http body' do
+        context 'with invalid JSON' do
+          let(:body) { '{"errors:["invalid"]}' }
+
+          it 'should not generate a parse error' do
+            expect { subject }.not_to raise_error
+          end
+
+          it 'should set parse error within #error_arr' do
+            expect(subject.error_arr.downcase).to include('unexpected token')
+          end
+        end
+
+        context 'with valid JSON array' do
+          let(:body) { '[]' }
+
+          it 'should not generate an error' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'with valid JSON hash' do
+          let(:body) { '{}' }
+
+          it 'should not generate an error' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context 'with array of errors in JSON hash' do
+          let(:body) { '{"errors":["error1", "error2"]}' }
+
+          it 'should append errors to exception message' do
+            expect(subject.message).to include('error1, error2')
+          end
+
+          it 'should return error with #error_arr' do
+            expect(subject.error_arr).to eq(['error1', 'error2'])
+          end
+        end
+
+        context 'with string errors in JSON hash' do
+          let(:body) { '{"errors":"error1"}' }
+
+          it 'should append error to exception message' do
+            expect(subject.message).to include('error1')
+            expect(subject.message).not_to include(',')
+          end
+
+          it 'should return error with #error_arr' do
+            expect(subject.error_arr).to eq('error1')
+          end
+        end
+
+        context 'with empty errors in JSON hash' do
+          let(:body) { '{"errors":""}' }
+
+          it 'should not modify the exception message' do
+            expect(subject.message).to eq(message)
+          end
+        end
+
+        context 'with null errors in JSON hash' do
+          let(:body) { '{"errors":null}' }
+
+          it 'should not modify the exception message' do
+            expect(subject.message).to eq(message)
+          end
+        end
+      end
+
+      context 'with http code' do
+        let(:code) { 404 }
+
+        it 'should return the code value' do
+          expect(subject.error_code).to eq(code)
+        end
+
+        it 'should be an integer' do
+          expect(subject.error_code).to be_a(Integer)
+        end
+
+        context 'with string type code' do
+          let(:code) { '404' }
+
+          it 'should return the integer value' do
+            expect(subject.error_code).to eq(404)
+          end
+
+          it 'should be an integer' do
+            expect(subject.error_code).to be_a(Integer)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It's rescuing the wrong error right now and that results in an error instead of the box being created.

Without this change you get this error:

```
VagrantCloud::ClientError: 404 Not Found - Resource not found!
from /usr/local/lib/ruby/gems/2.5.0/gems/vagrant_cloud-2.0.1/lib/vagrant_cloud/client.rb:55:in `rescue in request'
Caused by RestClient::NotFound: 404 Not Found
from /usr/local/lib/ruby/gems/2.5.0/gems/rest-client-2.0.2/lib/restclient/abstract_response.rb:223:in `exception_with_response'
```

Signed-off-by: Tim Smith <tsmith@chef.io>