### PR TITLE
Only update box if a hash if key/values is given

### DIFF
--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -33,10 +33,15 @@ module VagrantCloud
     # @param [Hash] args
     # @param [String] org - organization of the box to read
     # @param [String] box_name - name of the box to read
-    # @return [Hash]
+    # @return [Hash] @data
     def update(args = {})
       # hash arguments kept for backwards compatibility
-      data = @client.request('put', box_path(args[:organization], args[:name]), box: args)
+      return @data if args.empty?
+
+      org = args[:organization] || account.username
+      box_name = args[:name] || @name
+
+      data = @client.request('put', box_path(org, box_name), box: args)
 
       # Update was called on *this* object, so update
       # objects data locally

--- a/spec/vagrant_cloud/box_spec.rb
+++ b/spec/vagrant_cloud/box_spec.rb
@@ -62,6 +62,11 @@ module VagrantCloud
         expect(box.data).to eq(result)
       end
 
+      it 'returns empty if no args provided' do
+        box = Box.new(account, 'foo')
+        expect(box.update({})).to eq(nil)
+      end
+
       it 'sends a PUT request for a one-off update' do
         result = {
           'foo' => 'foo'


### PR DESCRIPTION
Prior to this commit, the update command would send an empty hash to
Vagrant Cloud if the Box.update method was called with no data. This
commit fixes that by returning early if an empty hash was given. It also
fails over to using the class instance variables for the box org and
name, if not given.