### PR TITLE
Fix yard param type for the Box class

### DIFF
--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -3,7 +3,7 @@ module VagrantCloud
     attr_accessor :account
     attr_accessor :name
 
-    # @param [String] account
+    # @param [VagrantCloud::Account] account
     # @param [String] name
     # @param [Hash] data
     # @param [String] description


### PR DESCRIPTION
This isn't a string. Confused me for a bit.