### PR TITLE
Pass access_token and base_url in ensure methods

### DIFF
--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -84,7 +84,7 @@ module VagrantCloud
     # @param [Hash] data
     # @return [Box]
     def get_box(name, data = nil)
-      Box.new(self, name, data)
+      Box.new(self, name, data, nil, nil, @client.access_token, @client.url_base)
     end
 
     # @param [String] name

--- a/lib/vagrant_cloud/box.rb
+++ b/lib/vagrant_cloud/box.rb
@@ -118,7 +118,7 @@ module VagrantCloud
 
     # @return [Array<Version>]
     def versions
-      version_list = data['versions'].map { |data| VagrantCloud::Version.new(self, data['number'], data) }
+      version_list = data['versions'].map { |data| VagrantCloud::Version.new(self, data['number'], data, nil, @client.access_token, @client.url_base) }
       version_list.sort_by { |version| Gem::Version.new(version.number) }
     end
 
@@ -130,7 +130,7 @@ module VagrantCloud
     # @param [Hash] data
     # @return [Version]
     def get_version(number, data = nil)
-      VagrantCloud::Version.new(self, number, data)
+      VagrantCloud::Version.new(self, number, data, nil, @client.access_token, @client.url_base)
     end
 
     # @param [String] name

--- a/lib/vagrant_cloud/client.rb
+++ b/lib/vagrant_cloud/client.rb
@@ -5,6 +5,7 @@ module VagrantCloud
     # Base Vagrant Cloud API URL
     URL_BASE = 'https://vagrantcloud.com/api/v1'.freeze
     attr_accessor :access_token
+    attr_accessor :url_base
 
     # @param [String] access_token - token used to authenticate API requests
     # @param [String] url_base - URL used to make API requests

--- a/lib/vagrant_cloud/version.rb
+++ b/lib/vagrant_cloud/version.rb
@@ -37,7 +37,7 @@ module VagrantCloud
 
     # @return [Array<Provider>]
     def providers
-      data['providers'].map { |data| Provider.new(self, data['name'], data) }
+      data['providers'].map { |data| Provider.new(self, data['name'], data, nil, nil, nil, @client.access_token, @client.url_base) }
     end
 
     # @return [String]
@@ -145,7 +145,7 @@ module VagrantCloud
     # @param [Hash] data
     # @return [Provider]
     def get_provider(name, data = nil)
-      Provider.new(self, name, data)
+      Provider.new(self, name, data, nil, nil, nil, @client.access_token, @client.url_base)
     end
 
     # @param [String] name

--- a/spec/vagrant_cloud/account_spec.rb
+++ b/spec/vagrant_cloud/account_spec.rb
@@ -188,5 +188,16 @@ module VagrantCloud
         expect(box).to eq(box_requested)
       end
     end
+
+    describe '.get_box' do
+      it 'returns a box with the client credentials and custom site of the account' do
+        account = VagrantCloud::Account.new('my-acc', 'my-token', 'my-custom-site')
+        box = account.get_box('foo')
+        client = box.instance_variable_get(:'@client')
+
+        expect(client.access_token).to eq('my-token')
+        expect(client.url_base).to eq('my-custom-site')
+      end
+    end
   end
 end

--- a/spec/vagrant_cloud/box_spec.rb
+++ b/spec/vagrant_cloud/box_spec.rb
@@ -37,6 +37,25 @@ module VagrantCloud
         expect(box.versions[0].number).to eq('1.0')
         expect(box.versions[1].number).to eq('2.0')
       end
+
+      it 'returns versions with the client credentials of the Box' do
+        data = { 'versions' => [{ 'number' => '1.2' }] }
+        box = Box.new(account, 'foo', data, nil, nil, 'my-token', 'my-custom-site')
+        versions = box.versions
+        client = versions.first.instance_variable_get(:'@client')
+        expect(client.access_token).to eq('my-token')
+        expect(client.url_base).to eq('my-custom-site')
+      end
+    end
+
+    describe '.get_version' do
+      it 'returns a version with the client credentials of the Box' do
+        box = Box.new(account, 'foo', nil, nil, nil, 'my-token', 'my-custom-site')
+        version = box.get_version('1.2')
+        client = version.instance_variable_get(:'@client')
+        expect(client.access_token).to eq('my-token')
+        expect(client.url_base).to eq('my-custom-site')
+      end
     end
 
     describe '.update' do

--- a/spec/vagrant_cloud/version_spec.rb
+++ b/spec/vagrant_cloud/version_spec.rb
@@ -112,6 +112,31 @@ module VagrantCloud
       end
     end
 
+    describe '.providers' do
+      it 'returns providers with the client credentials of the Version' do
+        data = { 'providers' => [{ 'name' => 'my-prov' }] }
+        version = Version.new(box, '1.2', data, nil, 'my-token', 'my-custom-site')
+
+        providers = version.providers
+        client = providers.first.instance_variable_get(:'@client')
+
+        expect(client.access_token).to eq('my-token')
+        expect(client.url_base).to eq('my-custom-site')
+      end
+    end
+
+    describe '.get_provider' do
+      it 'returns a provider with the client credentials of the Version' do
+        version = Version.new(box, '1.2', nil, nil, 'my-token', 'my-custom-site')
+
+        provider = version.get_provider('my-prov')
+        client = provider.instance_variable_get(:'@client')
+
+        expect(client.access_token).to eq('my-token')
+        expect(client.url_base).to eq('my-custom-site')
+      end
+    end
+
     describe '.create_provider' do
       it 'sends a POST request and returns the right instance' do
         result = { 'foo' => 'foo' }


### PR DESCRIPTION
This PR fixes issue #49 by passing the current object's access token when creating child objects.  I also noticed that in addition to the identified issue, that the same situation would be true for any custom servers defined when initializing the account as well, so the client's base_url is passed through as well.

Fixes #49 