### PR TITLE
Unrestrict rest-client version to allow to use rest-client 2.1+

### DIFF
--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/hashicorp/vagrant_cloud'
   s.license     = 'MIT'
 
-  s.add_runtime_dependency 'rest-client', '~> 2.0.2'
+  s.add_runtime_dependency 'rest-client', '~> 2.0'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
rest-client got recently updated in openSUSE which broke my builds of vagrant and vagrant_cloud, as it is pretty restrictive on the required version.

If possible, please tag a new release.