### PR TITLE
Automatically request callback on direct upload with block

### DIFF
--- a/lib/vagrant_cloud/box/provider.rb
+++ b/lib/vagrant_cloud/box/provider.rb
@@ -54,9 +54,9 @@ module VagrantCloud
       # option is enabled.
       #
       # If a block is provided, the upload URL will be yielded
-      # to the block. If the `direct` option is also set, the
-      # `DirectUpload` instance will be yielded and it is the
-      # block's responsibility to issue the callback request.
+      # to the block. If the `direct` option is set, the callback
+      # will be automatically requested after the block execution
+      # has completed.
       #
       # If no path or block is provided, the upload URL will
       # be returned. If the `direct` option is set, the
@@ -96,9 +96,9 @@ module VagrantCloud
           callback_url: r[:callback]
         )
         if block_given?
-          # When block is given and `direct` option is false, only yield
-          # the upload URL, otherwise yield the `DirectUpload` instance
-          yield direct ? result : result.upload_url
+          block_r = yield result.upload_url
+          Excon.put(result.callback_url) if direct
+          block_r
         elsif path
           File.open(path, "rb") do |file|
             chunks = lambda { file.read(Excon.defaults[:chunk_size]).to_s }

--- a/spec/unit/vagrant_cloud/box/provider_spec.rb
+++ b/spec/unit/vagrant_cloud/box/provider_spec.rb
@@ -251,16 +251,15 @@ describe VagrantCloud::Box::Provider do
           subject.upload(direct: true) { |du| }
         end
 
-        it "should yield DirectUpload which includes upload path" do
+        it "should yield the upload path" do
           subject.upload(direct: true) do |du|
-            expect(du.upload_url).to eq(upload_path)
+            expect(du).to eq(upload_path)
           end
         end
 
-        it "should yield DirectUpload which includes callback" do
-          subject.upload(direct: true) do |du|
-            expect(du.callback_url).to eq(callback)
-          end
+        it "should request the callback" do
+          expect(Excon).to receive(:put).with(callback)
+          subject.upload(direct: true) {|_|}
         end
 
         it "should return result of block" do


### PR DESCRIPTION
When a block is provided for a direct upload, yield the upload URL
to the block (as is done when non-direct). After executing the block,
request the callback to finalize the upload.
