### PR TITLE
Handful of small updates and fixes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,14 +1,14 @@
 on:
   push:
     branches:
-      - master
+      - main
       - 'test-*'
     paths:
       - 'lib/**'
       - 'spec/**'
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - 'lib/**'
       - 'spec/**'

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Release a new version:
 1. Update the version in the `version.txt` file
 1. Commit the change to master
 1. Create a new version tag in git: `git tag vX.X.X`
-1. Push the new tag and master to GitHub `git push origin master --tags`
+1. Push the new tag and master to GitHub `git push origin main --tags`
 
 The new release will be automatically built and published.
 

--- a/lib/vagrant_cloud/box/version.rb
+++ b/lib/vagrant_cloud/box/version.rb
@@ -36,7 +36,9 @@ module VagrantCloud
             version: version
           )
           # Remove self from box
-          box.versions.delete(self)
+          v = box.versions.dup
+          v.delete(self)
+          box.clean(data: {versions: v})
         end
         nil
       end

--- a/lib/vagrant_cloud/client.rb
+++ b/lib/vagrant_cloud/client.rb
@@ -91,8 +91,10 @@ module VagrantCloud
     # @param [Hash] params Parameters to send with request
     # @return [Hash]
     def request(path:, method: :get, params: {})
-      # Build the full path for the request and clean it
-      path = [path_base, path].compact.join("/").gsub(/\/{2,}/, "/")
+      if !path.start_with?(path_base)
+        # Build the full path for the request and clean it
+        path = [path_base, path].compact.join("/").gsub(/\/{2,}/, "/")
+      end
       method = method.to_s.downcase.to_sym
 
       # Build base request parameters
@@ -172,8 +174,12 @@ module VagrantCloud
           login: username,
           password: password
         },
-        description: description,
-        two_factor: code
+        token: {
+          description: description
+        },
+        two_factor: {
+          code: code
+        }
       }
       request(method: :post, path: "authenticate", params: params)
     end

--- a/lib/vagrant_cloud/error.rb
+++ b/lib/vagrant_cloud/error.rb
@@ -42,6 +42,7 @@ module VagrantCloud
       class ProviderNotFoundError < BoxError; end
       class VersionExistsError < BoxError; end
       class VersionStatusChangeError < BoxError; end
+      class VersionProviderExistsError < BoxError; end
     end
   end
 end

--- a/lib/vagrant_cloud/logger.rb
+++ b/lib/vagrant_cloud/logger.rb
@@ -26,11 +26,15 @@ module VagrantCloud
           # sure that the log level is an integer, as Log4r requires.
           level = nil if !level.is_a?(Integer)
 
-          base_formatter = Log4r::PatternFormatter.new(
-            pattern: "%d [%5l] %m",
-            date_pattern: "%F %T"
-          )
-          Log4r::Outputter.stderr.formatter = base_formatter
+          # Only override the log output format if the default is set
+          if Log4r::Outputter.stderr.formatter.is_a?(Log4r::DefaultFormatter)
+            base_formatter = Log4r::PatternFormatter.new(
+              pattern: "%d [%5l] %m",
+              date_pattern: "%F %T"
+            )
+            Log4r::Outputter.stderr.formatter = base_formatter
+          end
+
           logger = Log4r::Logger.new("vagrantcloud")
           logger.outputters = Log4r::Outputter.stderr
           logger.level = level

--- a/spec/unit/vagrant_cloud/box_spec.rb
+++ b/spec/unit/vagrant_cloud/box_spec.rb
@@ -148,17 +148,38 @@ describe VagrantCloud::Box do
   end
 
   describe "#versions_on_demand" do
-    it "should load versions when called" do
-      expect(account).to receive_message_chain(:client, :box_get).and_return(versions: [])
-      subject.versions_on_demand
+    context "when box exists" do
+      before { allow(subject).to receive(:exist?).and_return(true) }
+
+      it "should load versions when called" do
+        expect(account).to receive_message_chain(:client, :box_get).and_return(versions: [])
+        subject.versions_on_demand
+      end
+
+      it "should not load versions after initial load" do
+        expect(subject.dirty?(:versions)).to be_falsey
+        expect(account).to receive_message_chain(:client, :box_get).and_return(versions: [])
+        subject.versions_on_demand
+        expect(account).not_to receive(:client)
+        subject.versions_on_demand
+      end
     end
 
-    it "should not load versions after initial load" do
-      expect(subject.dirty?(:versions)).to be_falsey
-      expect(account).to receive_message_chain(:client, :box_get).and_return(versions: [])
-      subject.versions_on_demand
-      expect(account).not_to receive(:client)
-      subject.versions_on_demand
+    context "when box does not exist" do
+      before { allow(subject).to receive(:exist?).and_return(false) }
+
+      it "should not load versions when called" do
+        expect(account).not_to receive(:client)
+        subject.versions_on_demand
+      end
+
+      it "should not load versions after initial load" do
+        expect(subject.dirty?(:versions)).to be_falsey
+        expect(account).not_to receive(:client)
+        subject.versions_on_demand
+        expect(account).not_to receive(:client)
+        subject.versions_on_demand
+      end
     end
   end
 

--- a/spec/unit/vagrant_cloud/client_spec.rb
+++ b/spec/unit/vagrant_cloud/client_spec.rb
@@ -257,8 +257,8 @@ describe VagrantCloud::Client do
 
     it "should include description and code if provided" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :description)).to eq(description)
-        expect(args.dig(:params, :two_factor)).to eq(code)
+        expect(args.dig(:params, :token, :description)).to eq(description)
+        expect(args.dig(:params, :two_factor, :code)).to eq(code)
       end
       subject.authentication_token_create(username: username, password: password,
         description: description, code: code)


### PR DESCRIPTION
This PR includes a few API request fixes to match proper data
structure expected by the API (authentication related). It
also includes modifications on delete behavior when automatically
clearing the parent data structure to prevent attempted operations
on frozen data types. Finally some slight modifications have been
added to the provider upload behavior to include a callback proc
which can be used for completion notification (which will use the
configured client connection to include auth, etc) and updated
request methods based on type.