### PR TITLE
Wrap request errors

### DIFF
--- a/lib/vagrant_cloud/client.rb
+++ b/lib/vagrant_cloud/client.rb
@@ -126,7 +126,15 @@ module VagrantCloud
       # Set a request ID so we can track request/responses
       request_params[:headers] = {"X-Request-Id" => SecureRandom.uuid}
 
-      result = with_connection { |c| c.request(request_params) }
+      begin
+        result = with_connection { |c| c.request(request_params) }
+      rescue Excon::Error::HTTPStatus => err
+        raise Error::ClientError::RequestError.new(
+              "Vagrant Cloud request failed", err.response.body, err.response.status)
+      rescue Excon::Error => err
+        raise Error::ClientError, err.message
+      end
+
       parse_json(result.body)
     end
 

--- a/lib/vagrant_cloud/error.rb
+++ b/lib/vagrant_cloud/error.rb
@@ -2,8 +2,8 @@ module VagrantCloud
   class Error < StandardError
     class ClientError < Error
       class RequestError < ClientError
-        attr_accessor :error_arr
         attr_accessor :error_code
+        attr_accessor :error_arr
 
         def initialize(msg, http_body, http_code)
           message = msg
@@ -22,7 +22,7 @@ module VagrantCloud
             vagrant_cloud_msg = err.message
           end
 
-          @error_arr = vagrant_cloud_msg
+          @error_arr = Array(vagrant_cloud_msg)
           @error_code = http_code.to_i
           super(message)
         end

--- a/spec/unit/vagrant_cloud/client_spec.rb
+++ b/spec/unit/vagrant_cloud/client_spec.rb
@@ -207,6 +207,32 @@ describe VagrantCloud::Client do
         subject.request(path: "/", method: :post)
       end
     end
+
+    context "with errors" do
+      context "with request errors" do
+        let(:response) { double("response", status: 403, body: '{"errors": ["forbidden request"]}') }
+
+        before { expect(connection).to receive(:request).and_raise(Excon::Error::Forbidden.new("forbidden", nil, response)) }
+
+        it "should raise a wrapped error" do
+          expect { subject.request(path: "/") }.to raise_error(VagrantCloud::Error::ClientError::RequestError)
+        end
+
+        it "should set the error message from the content" do
+          err = nil
+          subject.request(path: "/")
+        rescue => err
+          expect(err.error_arr).to eq(["forbidden request"])
+        end
+
+        it "should set the error status code" do
+          err = nil
+          subject.request(path: "/")
+        rescue => err
+          expect(err.error_code).to eq(403)
+        end
+      end
+    end
   end
 
   describe "#clone" do


### PR DESCRIPTION
When errors are encountered when making remote requests, wrap
the error with our own custom error class. This removes reliance
on specific libraries for handling the underlying communcations.
