### PR TITLE
Add architecture support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,18 +15,18 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5.x', '2.6.x', '2.7.x', '3.0.x' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     name: Vagrant Cloud unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939
         with:
           ruby-version: ${{matrix.ruby}}
-          architecture: 'x64'
+          bundler-cache: true
       - name: Run Tests
-        run: .ci/test.sh
+        run: bundle exec rake

--- a/lib/vagrant_cloud/account.rb
+++ b/lib/vagrant_cloud/account.rb
@@ -75,7 +75,7 @@ module VagrantCloud
     #
     # @return [self]
     def validate_token
-      client.request(path: "authenticate")
+      client.authentication_token_validate
       self
     end
 
@@ -104,7 +104,7 @@ module VagrantCloud
 
     def setup!
       if client.access_token
-        r = client.request(path: "authenticate")
+        r = client.authentication_token_validate
         @username = r.dig(:user, :username)
       end
     end

--- a/lib/vagrant_cloud/box/version.rb
+++ b/lib/vagrant_cloud/box/version.rb
@@ -90,12 +90,19 @@ module VagrantCloud
       #
       # @param [String] pname Name of provider
       # @return [Provider]
-      def add_provider(pname)
-        if providers.any? { |p| p.name == pname }
+      def add_provider(pname, architecture=nil)
+        if providers.any? { |p|
+             p.name == pname &&
+               (architecture.nil? || p.architecture == architecture)
+           }
           raise Error::BoxError::VersionProviderExistsError,
-            "Provider #{pname} already exists for box #{box.tag} version #{version}"
+            "Provider #{pname} already exists for box #{box.tag} version #{version} (#{architecture})"
         end
-        pv = Provider.new(version: self, name: pname)
+        pv = Provider.new(
+          version: self,
+          name: pname,
+        )
+        pv.architecture = architecture if architecture
         clean(data: {providers: providers + [pv]})
         pv
       end

--- a/lib/vagrant_cloud/search.rb
+++ b/lib/vagrant_cloud/search.rb
@@ -43,10 +43,11 @@ module VagrantCloud
     # @param [String] limit
     # @param [String] page
     # @return [Response::Search]
-    def search(query: Data::Nil, provider: Data::Nil, sort: Data::Nil, order: Data::Nil, limit: Data::Nil, page: Data::Nil)
+    def search(query: Data::Nil, architecture: Data::Nil, provider: Data::Nil, sort: Data::Nil, order: Data::Nil, limit: Data::Nil, page: Data::Nil)
       @lock.synchronize do
         @params = {
           query: query,
+          architecture: architecture,
           provider: provider,
           sort: sort,
           order: order,

--- a/spec/unit/vagrant_cloud/account_spec.rb
+++ b/spec/unit/vagrant_cloud/account_spec.rb
@@ -10,7 +10,7 @@ describe VagrantCloud::Account do
 
   before do
     allow(VagrantCloud::Client).to receive(:new).with(hash_including(access_token: access_token)).and_return(client)
-    expect(client).to receive(:request).with(path: "authenticate").
+    allow(client).to receive(:authentication_token_validate).
       and_return(user: {username: username})
   end
 
@@ -99,7 +99,7 @@ describe VagrantCloud::Account do
 
   describe "#validate_token" do
     it "should call authenticate" do
-      expect(client).to receive(:request).with(path: "authenticate")
+      expect(client).to receive(:authentication_token_validate)
       subject.validate_token
     end
 
@@ -176,11 +176,11 @@ describe VagrantCloud::Account do
     let(:response) { {user: {username: different_username}} }
     let(:different_username) { double("different_username") }
 
-    before { allow(client).to receive(:request).with(path: "authenticate").
+    before { allow(client).to receive(:authentication_token_validate).
         and_return(response) }
 
     it "should make a request to authenticate" do
-      expect(client).to receive(:request).with(path: "authenticate").and_return(response)
+      expect(client).to receive(:authentication_token_validate).and_return(response)
       subject.send(:setup!)
     end
 
@@ -199,7 +199,7 @@ describe VagrantCloud::Account do
       end
 
       it "should not fetch the token username" do
-        expect(c).not_to receive(:request).with(path: "authenticate")
+        expect(c).not_to receive(:authentication_token_validate)
         expect(instance.send(:setup!)).to be_nil
       end
     end

--- a/spec/unit/vagrant_cloud/box/provider_spec.rb
+++ b/spec/unit/vagrant_cloud/box/provider_spec.rb
@@ -8,9 +8,15 @@ describe VagrantCloud::Box::Provider do
   let(:box_name) { double("box_name") }
   let(:version_version) { double("version_version") }
   let(:box_url) { double("box_url") }
+  let(:architecture) { "BOX_ARCHITECTURE" }
 
-
-  let(:subject) { described_class.new(version: version, name: provider_name) }
+  let(:subject) {
+    described_class.new(
+      version: version,
+      name: provider_name,
+      architecture: architecture
+    )
+  }
 
   before do
     allow(version).to receive(:is_a?).with(VagrantCloud::Box::Version).and_return(true)
@@ -76,6 +82,12 @@ describe VagrantCloud::Box::Provider do
       it "should send provider_name" do
         expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_delete).
           with(hash_including(provider: provider_name))
+        subject.delete
+      end
+
+      it "should send architecture" do
+        expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_delete).
+          with(hash_including(architecture: architecture))
         subject.delete
       end
 
@@ -423,11 +435,34 @@ describe VagrantCloud::Box::Provider do
         subject.send(:save_provider)
       end
 
+      it "should include architecture" do
+        expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_update).
+          with(hash_including(architecture: architecture)).and_return({})
+        subject.send(:save_provider)
+      end
+
+      it "should include new architecture" do
+        expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_update).
+          with(hash_including(new_architecture: architecture)).and_return({})
+        subject.send(:save_provider)
+      end
+
       it "should include URL" do
         subject.url = box_url
         expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_update).
           with(hash_including(url: box_url)).and_return({})
         subject.send(:save_provider)
+      end
+
+      context "when architecture is changed" do
+        let(:new_architecture) { "NEW_BOX_ARCHITECTURE" }
+
+        it "should include original and new architectures" do
+          subject.architecture = new_architecture
+          expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_update).
+            with(hash_including(new_architecture: new_architecture, architecture: architecture)).and_return({})
+          subject.send(:save_provider)
+        end
       end
     end
 
@@ -479,6 +514,12 @@ describe VagrantCloud::Box::Provider do
         subject.checksum_type = checksum_type
         expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_create).
           with(hash_including(checksum_type: checksum_type)).and_return({})
+        subject.send(:save_provider)
+      end
+
+      it "should include architecture" do
+        expect(version).to receive_message_chain(:box, :organization, :account, :client, :box_version_provider_create).
+          with(hash_including(architecture: architecture)).and_return({})
         subject.send(:save_provider)
       end
 

--- a/spec/unit/vagrant_cloud/box/version_spec.rb
+++ b/spec/unit/vagrant_cloud/box/version_spec.rb
@@ -179,6 +179,34 @@ describe VagrantCloud::Box::Version do
       expect { subject.add_provider("test") }.
         to raise_error(VagrantCloud::Error::BoxError::VersionProviderExistsError)
     end
+
+    context "with architecture" do
+      it "should add provider to collection and include architecture" do
+        pv = subject.add_provider("test", "test-arch")
+        expect(subject.providers).to include(pv)
+        expect(pv.architecture).to eq("test-arch")
+      end
+
+      it "should add multiple same providers with different architectures" do
+        ["arch1", "arch2", "arch3"].each do |arch|
+          pv = subject.add_provider("test", arch)
+          expect(subject.providers).to include(pv)
+          expect(pv.architecture).to eq(arch)
+        end
+      end
+
+      it "should raise error when provider exists" do
+        subject.add_provider("test", "test-arch")
+        expect { subject.add_provider("test", "test-arch") }.
+          to raise_error(VagrantCloud::Error::BoxError::VersionProviderExistsError)
+      end
+
+      it "should raise error when adding existing provider without architecture" do
+        subject.add_provider("test", "test-arch")
+        expect { subject.add_provider("test") }.
+          to raise_error(VagrantCloud::Error::BoxError::VersionProviderExistsError)
+      end
+    end
   end
 
   describe "#dirty?" do

--- a/spec/unit/vagrant_cloud/search_spec.rb
+++ b/spec/unit/vagrant_cloud/search_spec.rb
@@ -18,6 +18,7 @@ describe VagrantCloud::Search do
     allow(account).to receive(:is_a?).with(VagrantCloud::Account).and_return(true)
     allow(client).to receive(:is_a?).with(VagrantCloud::Client).and_return(true)
     allow(client_with_token).to receive(:request).and_return({})
+    allow(client_with_token).to receive(:authentication_token_validate).and_return({})
     allow(client).to receive(:search).and_return(response)
   end
 


### PR DESCRIPTION
Adds architecture support for box providers. Includes updates
to use the v2 API by default, and fallback to the v1 API when
required. 

Also includes update to search for applying an architecture
filter.
