### PR TITLE
Add support for HCP authentication

### DIFF
--- a/lib/vagrant_cloud.rb
+++ b/lib/vagrant_cloud.rb
@@ -8,6 +8,7 @@ require "thread"
 
 module VagrantCloud
   autoload :Account, "vagrant_cloud/account"
+  autoload :Auth, "vagrant_cloud/auth"
   autoload :Box, "vagrant_cloud/box"
   autoload :Client, "vagrant_cloud/client"
   autoload :Data, "vagrant_cloud/data"

--- a/lib/vagrant_cloud/auth.rb
+++ b/lib/vagrant_cloud/auth.rb
@@ -1,0 +1,140 @@
+require "oauth2"
+
+module VagrantCloud
+  class Auth
+
+    # Default authentication URL
+    DEFAULT_AUTH_URL = "https://auth.idp.hashicorp.com".freeze
+    # Default authorize path
+    DEFAULT_AUTH_PATH = "/oauth2/auth".freeze
+    # Default token path
+    DEFAULT_TOKEN_PATH = "/oauth2/token".freeze
+    # Number of seconds to pad token expiry
+    TOKEN_EXPIRY_PADDING = 5
+
+    # HCP configuration for generating authentication tokens
+    #
+    # @param [String] client_id Service principal client ID
+    # @param [String] client_secret Service principal client secret
+    # @param [String] auth_url Authentication URL end point
+    # @param [String] auth_path Authorization path (relative to end point)
+    # @param [String] token_path Token path (relative to end point)
+    HCPConfig = Struct.new(:client_id, :client_secret, :auth_url, :auth_path, :token_path, keyword_init: true) do
+      # Raise exception if any values are missing
+      def validate!
+        [:client_id, :client_secret, :auth_url, :auth_path, :token_path].each do |name|
+          raise ArgumentError,
+            "Missing required HCP authentication configuration value: HCP_#{name.to_s.upcase}" if self.send(name).to_s.empty?
+        end
+      end
+    end
+
+    # HCP token
+    #
+    # @param [String] token HCP token value
+    # @param [Integer] expires_at Epoch seconds
+    HCPToken = Struct.new(:token, :expires_at, keyword_init: true) do
+      # Raise exception if any values are missing
+      def validate!
+        [:token, :expires_at].each do |name|
+          raise ArgumentError,
+            "Missing required token value - #{name.inspect}" if self.send(name).nil?
+        end
+      end
+
+      # @return [Boolean] token is expired
+      # @note Will show token as expired TOKEN_EXPIRY_PADDING
+      # seconds prior to actual expiry
+      def expired?
+        validate!
+
+        Time.now.to_i > (expires_at - TOKEN_EXPIRY_PADDING)
+      end
+
+      # @return [Boolean] token is not expired
+      def valid?
+        !expired?
+      end
+    end
+
+    # Create a new auth instance
+    #
+    # @param [String] access_token Static access token
+    # @note If no access token is provided, the token will be extracted
+    # from the VAGRANT_CLOUD_TOKEN environment variable. If that value
+    # is not set, the HCP_CLIENT_ID and HCP_CLIENT_SECRET environment
+    # variables will be checked. If found, tokens will be generated as
+    # needed using the client id and secret. Otherwise, no token will
+    # will be available.
+    def initialize(access_token: nil)
+      @token = access_token
+
+      # The Vagrant Cloud token has precedence over
+      # anything else, so if it is set then it is
+      # the only value used.
+      @token = ENV["VAGRANT_CLOUD_TOKEN"] if @token.nil?
+
+      # If there is no token set, attempt to load HCP configuration
+      if @token.to_s.empty? && (ENV["HCP_CLIENT_ID"] || ENV["HCP_CLIENT_SECRET"])
+        @config = HCPConfig.new(
+          client_id: ENV["HCP_CLIENT_ID"],
+          client_secret: ENV["HCP_CLIENT_SECRET"],
+          auth_url: ENV.fetch("HCP_AUTH_URL", DEFAULT_AUTH_URL),
+          auth_path: ENV.fetch("HCP_AUTH_PATH", DEFAULT_AUTH_PATH),
+          token_path: ENV.fetch("HCP_TOKEN_PATH", DEFAULT_TOKEN_PATH)
+        )
+
+        # Validate configuration is populated
+        @config.validate!
+      end
+    end
+
+    # @return [String] authentication token
+    def token
+      # If a static token is defined, use that value
+      return @token if @token
+
+      # If no configuration is set, there is no auth to provide
+      return if @config.nil?
+
+      # If an HCP token exists and is not expired
+      return @hcp_token.token if @hcp_token&.valid?
+
+      # Generate a new HCP token
+      refresh_token!
+
+      @hcp_token.token
+    end
+
+    # @return [Boolean] Authentication token is available
+    def available?
+      !!(@token || @config)
+    end
+
+    private
+
+    # Refresh the HCP oauth2 token.
+    # @todo rescue exceptions and make them nicer
+    def refresh_token!
+      client = OAuth2::Client.new(
+        @config.client_id,
+        @config.client_secret,
+        site: @config.auth_url,
+        authorize_url: @config.auth_path,
+        token_url: @config.token_path,
+      )
+
+      begin
+        response = client.client_credentials.get_token
+        @hcp_token = HCPToken.new(
+          token: response.token,
+          expires_at: response.expires_at,
+        )
+      rescue OAuth2::Error => err
+        raise Error::AuthenticationError,
+          err.response.body.chomp,
+          err.response.status
+      end
+    end
+  end
+end

--- a/lib/vagrant_cloud/error.rb
+++ b/lib/vagrant_cloud/error.rb
@@ -29,6 +29,13 @@ module VagrantCloud
       end
 
       class ConnectionLockedError < ClientError; end
+      class AuthenticationError < ClientError
+        def initialize(msg, http_code)
+          @error_arr = [msg]
+          @error_code = http_code.to_i
+          super(msg)
+        end
+      end
     end
 
     class BoxError < Error

--- a/spec/unit/vagrant_cloud/auth_spec.rb
+++ b/spec/unit/vagrant_cloud/auth_spec.rb
@@ -1,0 +1,173 @@
+require 'spec_helper'
+require 'vagrant_cloud'
+
+describe VagrantCloud::Auth do
+  let(:client_id) { nil }
+  let(:client_secret) { nil }
+  let(:auth_url) { nil }
+  let(:auth_path) { nil }
+  let(:token_path) { nil }
+
+  # Remove any environment variables that
+  # maybe set that are used by auth
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("HCP_CLIENT_ID").and_return(client_id)
+    allow(ENV).to receive(:[]).with("HCP_CLIENT_SECRET").and_return(client_secret)
+    allow(ENV).to receive(:fetch) do |name, default_value|
+      send(name.sub("HCP_", "").downcase) || default_value
+    end
+  end
+
+  describe "#initialize" do
+    context "with no arguments" do
+      describe "#token" do
+        it "should return nil" do
+          expect(subject.token).to be_nil
+        end
+      end
+
+      describe "#available?" do
+        it "should return false" do
+          expect(subject).not_to be_available
+        end
+      end
+    end
+
+    context "with access token provided" do
+      let(:token) { "test-access-token" }
+      subject { described_class.new(access_token: token) }
+
+      describe "#token" do
+        it "should return the access token" do
+          expect(subject.token).to eq(token)
+        end
+      end
+
+      describe "#available?" do
+        it "should return true" do
+          expect(subject).to be_available
+        end
+      end
+    end
+
+    context "with HCP_CLIENT_ID only set" do
+      let(:client_id) { "test-client-id" }
+
+      describe "#initialize" do
+        it "should raise an argument error" do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context "with HCP_CLIENT_SECRET only set" do
+      let(:client_secret) { "test-client-secret" }
+
+      describe "#initialize" do
+        it "should raise an argument error" do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context "with HCP_CLIENT_ID and HCP_CLIENT_SECRET set" do
+      let(:client_secret) { "test-client-secret" }
+      let(:client_id) { "test-client-id" }
+
+      let(:token) { "test-access-token" }
+      let(:expires_at) { Time.now.to_i + 10 }
+      let(:token_response) { double(:token_response, token: token, expires_at: expires_at) }
+      let(:client) { double(:client, client_credentials: client_credentials) }
+      let(:client_credentials) { double(:client_credentials, get_token: token_response) }
+
+      let(:retry_token) { "retry-test-access-token" }
+      let(:retry_expires_at) { Time.now.to_i + 10 }
+      let(:retry_token_response) { double(:token_response, token: retry_token, expires_at: retry_expires_at) }
+      let(:retry_client_credentials) { double(:client_credentials, get_token: retry_token_response) }
+
+
+      before do
+        allow(OAuth2::Client).to receive(:new).and_return(client)
+      end
+
+      describe "#token" do
+        it "should return the access token" do
+          expect(subject.token).to eq(token)
+        end
+
+        context "with expired token" do
+          let(:expires_at) { Time.now.to_i - 5 }
+
+          before do
+            expect(client).to receive(:client_credentials).and_return(client_credentials)
+            expect(client).to receive(:client_credentials).and_return(retry_client_credentials)
+          end
+
+          it "should return the updated access token" do
+            subject.token # to seed the internal value
+            expect(subject.token).to eq(retry_token)
+          end
+        end
+
+        it "should properly configure the oauth2 client" do
+          expect(OAuth2::Client).to receive(:new).with(client_id, client_secret, hash_including(
+            site: described_class.const_get(:DEFAULT_AUTH_URL),
+            authorize_url: described_class.const_get(:DEFAULT_AUTH_PATH),
+            token_url: described_class.const_get(:DEFAULT_TOKEN_PATH),
+          )).and_return(client)
+
+          expect(subject.token).to eq(token)
+        end
+
+        context "with HCP_AUTH_URL set" do
+          let(:auth_url) { "https://example.com" }
+
+          it "should properly configure the oauth2 client" do
+            expect(OAuth2::Client).to receive(:new).with(client_id, client_secret, hash_including(
+              site: auth_url,
+              authorize_url: described_class.const_get(:DEFAULT_AUTH_PATH),
+              token_url: described_class.const_get(:DEFAULT_TOKEN_PATH),
+            )).and_return(client)
+
+            expect(subject.token).to eq(token)
+          end
+        end
+
+        context "with HCP_AUTH_PATH set" do
+          let(:auth_path) { "/auth/custom" }
+
+          it "should properly configure the oauth2 client" do
+            expect(OAuth2::Client).to receive(:new).with(client_id, client_secret, hash_including(
+              site: described_class.const_get(:DEFAULT_AUTH_URL),
+              authorize_url: auth_path,
+              token_url: described_class.const_get(:DEFAULT_TOKEN_PATH),
+            )).and_return(client)
+
+            expect(subject.token).to eq(token)
+          end
+        end
+
+        context "with HCP_TOKEN_PATH set" do
+          let(:token_path) { "/token/custom" }
+
+          it "should properly configure the oauth2 client" do
+            expect(OAuth2::Client).to receive(:new).with(client_id, client_secret, hash_including(
+              site: described_class.const_get(:DEFAULT_AUTH_URL),
+              authorize_url: described_class.const_get(:DEFAULT_AUTH_PATH),
+              token_url: token_path,
+            )).and_return(client)
+
+            expect(subject.token).to eq(token)
+          end
+        end
+      end
+
+      describe "#available?" do
+        it "should return true" do
+          expect(subject).to be_available
+        end
+      end
+    end
+  end
+end

--- a/vagrant_cloud.gemspec
+++ b/vagrant_cloud.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_runtime_dependency 'excon', '~> 1.0'
-  s.add_runtime_dependency 'log4r', '~> 1.1.10'
+  s.add_runtime_dependency 'log4r', '~> 1.1'
   s.add_runtime_dependency 'rexml', '~> 3.3'
+  s.add_runtime_dependency 'oauth2', '~> 2.0'
 
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Enables API requests to use a static access token value or to
generate tokens using an HCP service principal if the expected
environment variables are set. The authentication header is
no longer set at client initialization and is instead added to
the connection just prior to the request. This will allow the
token to be properly regenerated during long running processes
where the token may have expired.
