### PR TITLE
Fix box parameters in API calls, error namespace.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
             kv/data/github/hashicorp/vagrant_cloud-builder rubygems_api_key;
             kv/data/teams/vagrant/slack webhook;
       - name: Code Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         with:
           ruby-version: 3.1
       - name: Publish

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,9 +23,9 @@ jobs:
     name: Vagrant Cloud unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true

--- a/lib/vagrant_cloud/auth.rb
+++ b/lib/vagrant_cloud/auth.rb
@@ -131,7 +131,7 @@ module VagrantCloud
           expires_at: response.expires_at,
         )
       rescue OAuth2::Error => err
-        raise Error::AuthenticationError,
+        raise Error::ClientError::AuthenticationError,
           err.response.body.chomp,
           err.response.status
       end

--- a/lib/vagrant_cloud/client.rb
+++ b/lib/vagrant_cloud/client.rb
@@ -292,11 +292,13 @@ module VagrantCloud
     # @return [Hash] box information
     def box_create(username:, name:, short_description: Data::Nil, description: Data::Nil, is_private: Data::Nil)
       request(method: :post, path: '/boxes', params: {
-        username: username,
-        name: name,
-        short_description: short_description,
-        description: description,
-        is_private: is_private
+        box: {
+          username: username,
+          name: name,
+          short_description: short_description,
+          description: description,
+          is_private: is_private
+        }
       })
     end
 
@@ -310,9 +312,11 @@ module VagrantCloud
     # @return [Hash] box information
     def box_update(username:, name:, short_description: Data::Nil, description: Data::Nil, is_private: Data::Nil)
       params = {
-        short_description: short_description,
-        description: description,
-        is_private: is_private
+        box: {
+          short_description: short_description,
+          description: description,
+          is_private: is_private
+        }
       }
       request(method: :put, path: "/box/#{username}/#{name}", params: params)
     end

--- a/spec/unit/vagrant_cloud/client_spec.rb
+++ b/spec/unit/vagrant_cloud/client_spec.rb
@@ -3,6 +3,13 @@ require 'vagrant_cloud'
 
 describe VagrantCloud::Client do
   let(:connection) { double("connection", request: nil) }
+  let(:oauth_client) { double("oauth", client_credentials: client_credentials) }
+  let(:client_credentials) { double("client_credentials", get_token: token) }
+  let(:token) { VagrantCloud::Auth::HCPToken.new(token: "stub", expires_at: Time.now.to_i + 100) }
+
+  before do
+    allow(OAuth2::Client).to receive(:new).and_return(oauth_client)
+  end
 
   describe "#intialize" do
     context "with no arguments" do
@@ -20,10 +27,6 @@ describe VagrantCloud::Client do
 
       it "should have #instrumentor set" do
         expect(subject.instrumentor).not_to be_nil
-      end
-
-      it "should not have #access_token set" do
-        expect(subject.access_token).to be_nil
       end
     end
 
@@ -482,21 +485,21 @@ describe VagrantCloud::Client do
 
     it "should include description" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :description)).to eq(description)
+        expect(args.dig(:params, :box, :description)).to eq(description)
       end
       subject.box_create(username: username, name: name, description: description)
     end
 
     it "should include short_description" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :short_description)).to eq(short_description)
+        expect(args.dig(:params, :box, :short_description)).to eq(short_description)
       end
       subject.box_create(username: username, name: name, short_description: short_description)
     end
 
     it "should include is_private" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :is_private)).to eq(is_private)
+        expect(args.dig(:params, :box, :is_private)).to eq(is_private)
       end
       subject.box_create(username: username, name: name, is_private: is_private)
     end
@@ -526,21 +529,21 @@ describe VagrantCloud::Client do
 
     it "should include description" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :description)).to eq(description)
+        expect(args.dig(:params, :box, :description)).to eq(description)
       end
       subject.box_update(username: username, name: name, description: description)
     end
 
     it "should include short_description" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :short_description)).to eq(short_description)
+        expect(args.dig(:params, :box, :short_description)).to eq(short_description)
       end
       subject.box_update(username: username, name: name, short_description: short_description)
     end
 
     it "should include is_private" do
       expect(subject).to receive(:request) do |args|
-        expect(args.dig(:params, :is_private)).to eq(is_private)
+        expect(args.dig(:params, :box, :is_private)).to eq(is_private)
       end
       subject.box_update(username: username, name: name, is_private: is_private)
     end


### PR DESCRIPTION
Fixes the box create / update calls to nest values within a `box`
key as defined by the API. Custom error raised on authentication
failure was improperly namespaced and has been updated to the
correct namespace.
